### PR TITLE
Updating the import of go-uuid

### DIFF
--- a/queue/storage.go
+++ b/queue/storage.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 
 	"encoding/json"
 	"io"


### PR DESCRIPTION
From the current page of `code.google.com/p/go-uuid/uuid`:

> project has been moved to https://github.com/pborman/uuid.